### PR TITLE
suppress a warning about let block on 36.0

### DIFF
--- a/uc/uc.jsm
+++ b/uc/uc.jsm
@@ -42,7 +42,8 @@ for(let it in new Iterator({
   transferable:
   ['@mozilla.org/widget/transferable;1',
    'nsITransferable'],
-})) let([name, [cid, iid]] = it){
+})) {
+  let [name, [cid, iid]] = it
   cid = Cc[cid]
   iid = Ci[iid]
   UC.__defineGetter__(name, function UC_i() cid.createInstance(iid))


### PR DESCRIPTION
This change suppresses a warning of "JavaScript 1.7's let blocks are deprecated" on Firefox 36.0's Browser Console.

![screenshot](https://cloud.githubusercontent.com/assets/69238/6933315/52deb540-d860-11e4-9343-e154191c40dc.PNG)
- https://developer.mozilla.org/en-US/Firefox/Releases/36/Site_Compatibility#let_blocks_and_expressions_have_been_deprecated
- https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/let#let_block
